### PR TITLE
[5주차] 이태용 과제 제출

### DIFF
--- a/태용/Week5_HowToUseAPI.js
+++ b/태용/Week5_HowToUseAPI.js
@@ -1,0 +1,25 @@
+import axios from 'axios';
+
+function callApi() {
+    axios.get('https://reqres.in/api/users/2')
+        .then(function response() {
+            console.log(response); 
+        })
+        .catch(function error() {
+            console.error(error);
+        });
+}
+callApi();
+
+
+/*
+import axios from 'axios';
+
+async function callApi() {
+    const response = await axios.get('https://reqres.in/api/users/2');
+    console.log(response);
+  }
+}
+callApi();
+
+*/

--- a/태용/Week6_scopeAnswer.md
+++ b/태용/Week6_scopeAnswer.md
@@ -1,0 +1,13 @@
+# Week6_Scope
+> 1. Does a function pickup latest changes?
+>> - 함수 `sayHi()`는 변수 `name`을 따르게 된다.
+>> - 함수가 실행될 때, 변수 `name`의 제일 최근에 변경된 값이 "Pete"이므로 "Hi, Pete"를 alert 한다.
+***
+> 2. Which variables are available?
+>> - `makeWorker()` 함수는 생성된 장소의 외부 변수에 접근할 수 있다. (It will have access to the outer variables from its creation place.)
+>> - 따라서 `work()`를 실행하면 "Pete"를 alert 한다.
+>> - 리턴된 함수는 **클로저(closure)** 로,  생성될 때 만들어진 스코프의 변수에 대한 참조를 유지한다. `makeWorker()` 함수 내부에서 생성된 함수는 `makeWorker()` 의 스코프에서 정의된 변수인 `name`에 접근하게 된다. 
+***
+> 3. counter는 독립적일까요?
+>> - `counter`와 `counter2`는 독립적인 클로저이므로. 각각의 클로저는 따로 `count` 를 갖고 독립적으로 증가하게 된다.
+>> - 그러므로 `counter2()`는 독립적인 클로저이므로 0이 출력되고, 재호출시 1이 출력된다. 따라서 0, 1이 출력된다.


### PR DESCRIPTION
- 프로토타입을 그대로 사용하면 정상적으로 값이 출력되지 않는 이유는 비동기 HTTP 요청을 처리하는 axios 라이브러리를 사용하지 않았고, API 호출이 비동기적으로 처리되지 않았기 때문입니다. 프로토타입에서는 비동기 작업인 API 호출이, 동기적으로 처리되므로 응답을 받을 때까지 대기하지 않고 다음 코드를 바로 실행합니다.
- `npm install axios` 으로 서버에서 axios를 설치
- 코드가 2개 있는데, 첫번째는 `axios.get()` 메서드로 API를 호출하고 `then()` 메서드로 응답 받았을 때, 데이터를 출력하고, `catch()` 메서드로 에러를 출력합니다. 
- `then/catch`를 사용하지 않았을 때는 비동기 작업의 완료 또는 실패와 그 결과 값을 나타내는 `Promise` 객체가 출력되므로 실제 응답 데이터가 출력되지 않습니다. `axios.get()`가 비동기 작업이기 때문이라는 것을 알 수 있었습니다.
- 두번째는 비동기 작업을 처리하기 위한 기능인 `async/await` 문법을 이용한 코드입니다. `await`는 비동기 작업이 완료될 때까지 `async` 함수의 실행을 일시 중지하고, 작업이 완료된 후 그 결과를 리턴합니다.
- 가독성 측면에서나 스타일적 측면에서 보았을 때,  `async/await` 문법을 사용 하는 것이 더 편해보입니다.